### PR TITLE
Port to Forge 41.0.99, optimise a tad, fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
-version = '1.19.x-1.0.0'
+version = '1.19.x-1.0.1'
 group = 'com.vandendaelen' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'nicephore'
 
@@ -17,7 +17,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
-    mappings channel: 'parchment', version: '1.18.2-2022.06.05-1.19'
+    mappings channel: 'parchment', version: '1.18.2-2022.07.10-1.19'
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -118,7 +118,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19-41.0.1'
+    minecraft 'net.minecraftforge:forge:1.19-41.0.99'
     implementation 'com.profesorfalken:jPowerShell:3.1.1'
     shade 'com.profesorfalken:jPowerShell:3.1.1'
     library 'com.profesorfalken:jPowerShell:3.1.1'

--- a/src/main/java/com/vandendaelen/nicephore/Nicephore.java
+++ b/src/main/java/com/vandendaelen/nicephore/Nicephore.java
@@ -1,16 +1,12 @@
 package com.vandendaelen.nicephore;
 
 import com.mojang.logging.LogUtils;
-import com.vandendaelen.nicephore.client.event.ClientEvents;
 import com.vandendaelen.nicephore.config.NicephoreConfig;
-import com.vandendaelen.nicephore.thread.InitThread;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.network.NetworkConstants;
 import org.slf4j.Logger;
 
@@ -22,17 +18,9 @@ public final class Nicephore {
     public static final String MOD_NAME = "Nicephore";
 
     public Nicephore() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, NicephoreConfig.CLIENT_SPEC);
         MinecraftForge.EVENT_BUS.register(this);
 
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-    }
-
-    private void doClientStuff(final FMLClientSetupEvent event) {
-        ClientEvents.init();
-
-        final InitThread initThread = new InitThread(NicephoreConfig.Client.getOptimisedOutputToggle());
-        initThread.start();
     }
 }

--- a/src/main/java/com/vandendaelen/nicephore/client/KeyMappings.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/KeyMappings.java
@@ -1,0 +1,18 @@
+package com.vandendaelen.nicephore.client;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.vandendaelen.nicephore.Nicephore;
+import net.minecraft.client.KeyMapping;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import org.lwjgl.glfw.GLFW;
+
+public class KeyMappings {
+    public static final KeyMapping COPY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.copy", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_C), Nicephore.MOD_NAME);
+    public static final KeyMapping GUI_SCREENSHOT_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.screenshots.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_S), Nicephore.MOD_NAME);
+    public static final KeyMapping GUI_GALLERY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.gallery.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_G), Nicephore.MOD_NAME);
+
+    private static InputConstants.Key getKey(final int key) {
+        return InputConstants.Type.KEYSYM.getOrCreate(key);
+    }
+}

--- a/src/main/java/com/vandendaelen/nicephore/client/KeyMappings.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/KeyMappings.java
@@ -7,12 +7,26 @@ import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;
 import org.lwjgl.glfw.GLFW;
 
-public class KeyMappings {
-    public static final KeyMapping COPY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.copy", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_C), Nicephore.MOD_NAME);
-    public static final KeyMapping GUI_SCREENSHOT_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.screenshots.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_S), Nicephore.MOD_NAME);
-    public static final KeyMapping GUI_GALLERY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.gallery.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_G), Nicephore.MOD_NAME);
+public enum KeyMappings {
+    COPY_KEY("copy", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, GLFW.GLFW_KEY_C),
+    GUI_SCREENSHOT_KEY("screenshots.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, GLFW.GLFW_KEY_S),
+    GUI_GALLERY_KEY("gallery.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, GLFW.GLFW_KEY_G);
+
+    private final KeyMapping key;
+
+    KeyMappings(String localizationKey, KeyConflictContext context, KeyModifier modifier, int key) {
+        this.key = new KeyMapping(Nicephore.MODID + ".keybinds." + localizationKey, context, modifier, getKey(key), Nicephore.MOD_NAME);
+    }
+
+    public boolean consumeClick() {
+        return getKey().consumeClick();
+    }
 
     private static InputConstants.Key getKey(final int key) {
         return InputConstants.Type.KEYSYM.getOrCreate(key);
+    }
+
+    public KeyMapping getKey() {
+        return key;
     }
 }

--- a/src/main/java/com/vandendaelen/nicephore/client/event/ClientForgeBusEvents.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/event/ClientForgeBusEvents.java
@@ -1,64 +1,47 @@
 package com.vandendaelen.nicephore.client.event;
 
-import com.mojang.blaze3d.platform.InputConstants;
 import com.vandendaelen.nicephore.Nicephore;
+import com.vandendaelen.nicephore.client.KeyMappings;
 import com.vandendaelen.nicephore.client.gui.GalleryScreen;
 import com.vandendaelen.nicephore.client.gui.ScreenshotScreen;
 import com.vandendaelen.nicephore.config.NicephoreConfig;
+import com.vandendaelen.nicephore.thread.InitThread;
 import com.vandendaelen.nicephore.thread.ScreenshotThread;
 import com.vandendaelen.nicephore.utils.CopyImageToClipBoard;
 import com.vandendaelen.nicephore.utils.PlayerHelper;
-import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
-import net.minecraftforge.client.settings.KeyConflictContext;
-import net.minecraftforge.client.settings.KeyModifier;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
-import org.lwjgl.glfw.GLFW;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
-@EventBusSubscriber(value = Dist.CLIENT, modid = Nicephore.MODID)
-public final class ClientEvents {
-    public static KeyMapping COPY_KEY;
-    public static KeyMapping GUI_SCREENSHOT_KEY;
-    public static KeyMapping GUI_GALLERY_KEY;
+@Mod.EventBusSubscriber(value = Dist.CLIENT, modid = Nicephore.MODID)
+public final class ClientForgeBusEvents {
 
-    static InputConstants.Key getKey(final int key) {
-        return InputConstants.Type.KEYSYM.getOrCreate(key);
-    }
-
-    public static void init() {
-        COPY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.copy", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_C), Nicephore.MOD_NAME);
-        ClientRegistry.registerKeyBinding(COPY_KEY);
-        GUI_SCREENSHOT_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.screenshots.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_S), Nicephore.MOD_NAME);
-        ClientRegistry.registerKeyBinding(GUI_SCREENSHOT_KEY);
-        GUI_GALLERY_KEY = new KeyMapping(Nicephore.MODID + ".keybinds.gallery.gui", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, getKey(GLFW.GLFW_KEY_G), Nicephore.MOD_NAME);
-        ClientRegistry.registerKeyBinding(GUI_GALLERY_KEY);
+    @SubscribeEvent
+    public static void onClientSetup(final FMLClientSetupEvent event) {
+        final InitThread initThread = new InitThread(NicephoreConfig.Client.getOptimisedOutputToggle());
+        initThread.start();
     }
 
     @SubscribeEvent
-    public static void onKey(final InputEvent.KeyInputEvent event) {
-        if (COPY_KEY.consumeClick()) {
+    public static void onKey(final InputEvent.Key event) {
+        if (KeyMappings.COPY_KEY.consumeClick()) {
             if (CopyImageToClipBoard.getInstance().copyLastScreenshot()) {
                 PlayerHelper.sendMessage(Component.translatable("nicephore.clipboard.success"));
             } else {
                 PlayerHelper.sendMessage(Component.translatable("nicephore.clipboard.error"));
             }
-        }
-
-        if (GUI_SCREENSHOT_KEY.consumeClick()) {
+        } else if (KeyMappings.GUI_SCREENSHOT_KEY.consumeClick()) {
             if (ScreenshotScreen.canBeShow()) {
                 Minecraft.getInstance().setScreen(new ScreenshotScreen());
             } else {
                 PlayerHelper.sendHotbarMessage(Component.translatable("nicephore.screenshots.empty"));
             }
-        }
-
-        if (GUI_GALLERY_KEY.consumeClick()) {
+        } else if (KeyMappings.GUI_GALLERY_KEY.consumeClick()) {
             if (GalleryScreen.canBeShow()) {
                 Minecraft.getInstance().setScreen(new GalleryScreen());
             } else {

--- a/src/main/java/com/vandendaelen/nicephore/client/event/ClientModBusEvents.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/event/ClientModBusEvents.java
@@ -7,13 +7,15 @@ import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.Arrays;
+
 @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = Nicephore.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public final class ClientModBusEvents {
 
     @SubscribeEvent
     public static void onKeyMappingsRegistration(final RegisterKeyMappingsEvent event) {
-        event.register(KeyMappings.COPY_KEY);
-        event.register(KeyMappings.GUI_SCREENSHOT_KEY);
-        event.register(KeyMappings.GUI_GALLERY_KEY);
+        Arrays.stream(KeyMappings.values())
+                .map(KeyMappings::getKey)
+                .forEach(event::register);
     }
 }

--- a/src/main/java/com/vandendaelen/nicephore/client/event/ClientModBusEvents.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/event/ClientModBusEvents.java
@@ -1,0 +1,19 @@
+package com.vandendaelen.nicephore.client.event;
+
+import com.vandendaelen.nicephore.Nicephore;
+import com.vandendaelen.nicephore.client.KeyMappings;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(value = Dist.CLIENT, modid = Nicephore.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public final class ClientModBusEvents {
+
+    @SubscribeEvent
+    public static void onKeyMappingsRegistration(final RegisterKeyMappingsEvent event) {
+        event.register(KeyMappings.COPY_KEY);
+        event.register(KeyMappings.GUI_SCREENSHOT_KEY);
+        event.register(KeyMappings.GUI_GALLERY_KEY);
+    }
+}

--- a/src/main/java/com/vandendaelen/nicephore/client/gui/DeleteConfirmScreen.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/gui/DeleteConfirmScreen.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.io.File;
@@ -42,7 +43,7 @@ public class DeleteConfirmScreen extends Screen {
     }
 
     @Override
-    public void render(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+    public void render(@NotNull PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(matrixStack);
         super.render(matrixStack, mouseX, mouseY, partialTicks);
 

--- a/src/main/java/com/vandendaelen/nicephore/client/gui/GalleryScreen.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/gui/GalleryScreen.java
@@ -14,6 +14,7 @@ import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -108,7 +109,7 @@ public class GalleryScreen extends Screen implements FilterListener {
     }
 
     @Override
-    public void render(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+    public void render(@NotNull PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
         final int centerX = this.width / 2;
         final int imageWidth = (int) (this.width * 1.0 / 5);
         final int imageHeight = (int) (imageWidth / aspectRatio);
@@ -188,6 +189,9 @@ public class GalleryScreen extends Screen implements FilterListener {
         var numberOfPages = getNumberOfPages();
         if (index >= numberOfPages || index < 0) {
             index = (int) numberOfPages - 1;
+        }
+        if (index < 0) {
+            index = 0;
         }
         return index;
     }

--- a/src/main/java/com/vandendaelen/nicephore/client/gui/GalleryScreen.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/gui/GalleryScreen.java
@@ -61,7 +61,7 @@ public class GalleryScreen extends Screen implements FilterListener {
     }
 
     private long getNumberOfPages() {
-        return Math.round(getNumberOfFiles(SCREENSHOTS_DIR) / (double) IMAGES_TO_DISPLAY);
+        return (long) Math.ceil(getNumberOfFiles(SCREENSHOTS_DIR) / (double) IMAGES_TO_DISPLAY);
     }
 
     @Override
@@ -187,11 +187,8 @@ public class GalleryScreen extends Screen implements FilterListener {
 
     private int getIndex() {
         var numberOfPages = getNumberOfPages();
-        if (index >= numberOfPages || index < 0) {
+        if (index > numberOfPages || index < 0) {
             index = (int) numberOfPages - 1;
-        }
-        if (index < 0) {
-            index = 0;
         }
         return index;
     }

--- a/src/main/java/com/vandendaelen/nicephore/client/gui/ScreenshotScreen.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/gui/ScreenshotScreen.java
@@ -16,6 +16,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -126,7 +127,7 @@ public class ScreenshotScreen extends Screen {
     }
 
     @Override
-    public void render(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+    public void render(@NotNull PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
         final int centerX = this.minecraft.getWindow().getGuiScaledWidth() / 2;
         final int pictureMidWith = (int) (this.minecraft.getWindow().getGuiScaledWidth() * 0.5 * 1.2);
         final int pictureHeight = (int) (pictureMidWith / aspectRatio);

--- a/src/main/java/com/vandendaelen/nicephore/client/gui/SettingsScreen.java
+++ b/src/main/java/com/vandendaelen/nicephore/client/gui/SettingsScreen.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 
@@ -17,7 +18,7 @@ public class SettingsScreen extends Screen {
     }
 
     @Override
-    public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
+    public void render(@NotNull PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
         this.renderBackground(pPoseStack);
         final int centerX = this.width / 2;
         final int startingLine = this.width / 2 - 150;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -41,7 +41,7 @@ This Forge mod makes it quicker to share screenshots online by giving you the ab
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[41,)" #mandatory
+    versionRange="[41.0.99,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,8 @@
 {
     "pack": {
-        "description": "nicephore resources",
-        "pack_format": 9
+        "description": "Nicephore resources",
+        "pack_format": 9,
+        "forge:resource_pack_format": 9,
+        "forge:data_pack_format": 10
     }
 }


### PR DESCRIPTION
- Fix crash when opening gallery
The gallery screen seems pretty broken atm - with my simple fix it at least displays now, but it shows "Page 1 of 0" and crashes if you click the next page button.

- Fix crash when running on server
The mod's main class was referencing client-only things, potentially causing a class not found crash on dedicated servers. I've moved this to ClientModBusEvents and renamed ClientEvents to ClientForgeBusEvents

- Fixed datapack incompatibility warning

- Don't check if people are simultaneously pressing the gallery, screenshot and copy key mappings